### PR TITLE
Add aarch64-specific paths to CMake build flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,11 +12,12 @@ set(OPT_FLAGS "-Ofast -march=native")
 #set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OPT_FLAGS}")
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OPT_FLAGS}")
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-value -fPIC")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-value -fPIC")
-
-set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath-link=/usr/lib/aarch64-linux-gnu/nvidia")
+# Add the specific paths for aarch64 libraries and include files
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -Wextra -Wno-unused-value -fPIC -I/usr/include/aarch64-linux-gnu")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -Wextra -Wno-unused-value -fPIC -I/usr/include/aarch64-linux-gnu")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath-link=/usr/lib/aarch64-linux-gnu/nvidia -L/usr/lib/aarch64-linux-gnu")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath-link=/usr/local/cuda/lib64")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L/usr/lib/aarch64-linux-gnu")
 
 find_library(LIB_V4L2 nvv4l2 PATHS /usr/lib/aarch64-linux-gnu/nvidia)
 find_library(message (STATUS "LIB_NVJPEG: ${LIB_NVJPEG}") nvjpeg PATHS /usr/lib/aarch64-linux-gnu/nvidia)


### PR DESCRIPTION
Include aarch64 library and include file paths in CMake CXX and C flags. Also, update shared and executable linker flags to reference aarch64 directories. This ensures proper linking and compilation for aarch64 targets.